### PR TITLE
Do not serialize an originally non-json string to json

### DIFF
--- a/MD2RT/MD2RT.cs
+++ b/MD2RT/MD2RT.cs
@@ -21,7 +21,7 @@ public class MD2RT
 
     var json = ProseMirrorConvert.SerializeToJson(obj);
 
-    return JsonConvert.SerializeObject(json);
+    return isJsonString ? JsonConvert.SerializeObject(json) : json;
   }
 
   public static void Process(object? root, string uiHintSource, string uiHintTarget, string appendTarget, bool isJsonString = true, ILogger? logger = null)


### PR DESCRIPTION
Wanneer de originele markdown geen json string is, moet er ook geen extra serialisatie-slag aan het eind gedaan worden.